### PR TITLE
[FEAT] Add JWT auth routes and refactor auth view structure

### DIFF
--- a/apps/auths/schemas.py
+++ b/apps/auths/schemas.py
@@ -1,0 +1,55 @@
+from drf_spectacular.utils import extend_schema, extend_schema_view, OpenApiResponse
+from rest_framework import serializers
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
+from auths.serializers import AuthSerializer
+
+class TokenResponseSerializer(serializers.Serializer):
+    access = serializers.CharField()
+    refresh = serializers.CharField()
+
+init_admin_schema = extend_schema(
+    request=AuthSerializer,
+    responses={
+        200: OpenApiResponse(description="Account created successfully")
+    },
+    summary="Initialize the first administrator"
+)
+
+create_user_schema = extend_schema(
+    request=AuthSerializer,
+    responses={
+        200: OpenApiResponse(description="Account created successfully")
+    },
+    summary="Create a new user"
+)
+
+create_employee_schema = extend_schema(
+    request=AuthSerializer,
+    responses={
+        200: OpenApiResponse(description="Account created successfully")
+    },
+    summary="Create a new employee"
+)
+
+token_schema = extend_schema(
+    request=TokenObtainPairSerializer,
+    responses=TokenResponseSerializer,
+    summary="Login",
+    description="Obtain a JWT token with email and password"
+)
+
+refresh_schema = extend_schema(
+    request=TokenRefreshSerializer,
+    responses=TokenResponseSerializer,
+    summary="Refresh",
+    description="Refresh the JWT token"
+)
+
+
+auth_schema = extend_schema_view(
+    token=token_schema,
+    token_refresh=refresh_schema,
+    init_admin=init_admin_schema,
+    create_user=create_user_schema,
+    create_employee=create_employee_schema
+)

--- a/apps/auths/tests/auth_service_test.py
+++ b/apps/auths/tests/auth_service_test.py
@@ -1,4 +1,5 @@
 import pytest
+from rest_framework.test import APIClient
 from auths.services import AuthService
 from auths.models import Auth
 
@@ -65,3 +66,44 @@ def test_create_user():
 
     assert employee.email == data["email"]
     assert employee.role == "user"
+
+@pytest.mark.django_db
+def test_token_obtain_success():
+    client = APIClient()
+
+    Auth.objects.create_user(
+        email="user@example.com",
+        password="Secure123A"
+    )
+
+    response = client.post("/auth/token/", {
+        "email": "user@example.com",
+        "password": "Secure123A"
+    })
+
+    assert response.status_code == 200
+    assert "access" in response.data
+    assert "refresh" in response.data
+
+@pytest.mark.django_db
+def test_token_refresh_success():
+    client = APIClient()
+
+    user = Auth.objects.create_user(
+        email="user@example.com",
+        password="Secure123A"
+    )
+
+    token_response = client.post("/auth/token/", {
+        "email": "user@example.com",
+        "password": "Secure123A"
+    })
+
+    refresh_token = token_response.data["refresh"]
+
+    response = client.post("/auth/token/refresh/", {
+        "refresh": refresh_token
+    })
+
+    assert response.status_code == 200
+    assert "access" in response.data

--- a/apps/auths/views/auth_view.py
+++ b/apps/auths/views/auth_view.py
@@ -3,22 +3,17 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
 from drf_spectacular.utils import extend_schema, OpenApiResponse
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer, TokenRefreshSerializer
 
+from auths.schemas import auth_schema
 from auths.serializers import AuthSerializer
 from auths.services import AuthService
 from auths.permissions import IsFirstUser, IsAdminUser
 
+@auth_schema
 class AuthView(ViewSet):
     """ViewSet for user-related operations including registration, admin initialization, and employee creation."""
-    @extend_schema(
-        request=AuthSerializer,
-        responses={
-            200: OpenApiResponse(
-              description="Account created successfully"
-            )
-          },
-        summary="Initialize the first administrator"
-    )
+
     @action(detail=False, methods=['post'], url_path='init', permission_classes=[IsFirstUser])
     def init_admin(self, request):
         """Creates the first admin user if no users exist."""
@@ -27,15 +22,6 @@ class AuthView(ViewSet):
         AuthService.add_admin(serializer.validated_data)
         return Response({ "message": "Account created successfully" }, status=status.HTTP_200_OK)
 
-    @extend_schema(
-        request=AuthSerializer,
-        responses={
-            200: OpenApiResponse(
-                description="Account created successfully"
-            )
-        },
-        summary="Create a new user"
-    )
     @action(detail=False, methods=['post'], url_path='register')
     def create_user(self, request):
         """Creates a regular user."""
@@ -44,15 +30,6 @@ class AuthView(ViewSet):
         AuthService.add(serializer.validated_data)
         return Response({ "message": "Account created successfully" }, status=status.HTTP_200_OK)
 
-    @extend_schema(
-        request=AuthSerializer,
-        responses={
-            200: OpenApiResponse(
-                description="Account created successfully"
-            )
-        },
-        summary="Create a new employee"
-    )
     @action(detail=False, methods=['post'], url_path='employee', permission_classes=[IsAdminUser])
     def create_employee(self, request):
         """Creates an employee user. Only accessible by admin users."""
@@ -60,3 +37,15 @@ class AuthView(ViewSet):
         serializer.is_valid(raise_exception=True)
         AuthService.add_employee(serializer.validated_data)
         return Response({ "message": "Account created successfully" }, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['post'], url_path='token')
+    def token(self, request):
+        serializer = TokenObtainPairSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['post'], url_path='token/refresh')
+    def token_refresh(self, request):
+        serializer = TokenRefreshSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.validated_data, status=status.HTTP_200_OK)

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,1 +1,2 @@
 -r base.txt
+pytest-django

--- a/shared/utils/run_tests.ps1
+++ b/shared/utils/run_tests.ps1
@@ -1,0 +1,3 @@
+$env:PYTHONPATH="apps"
+$env:DJANGO_SETTINGS_MODULE="core.settings.dev"
+pytest apps/auths/tests/


### PR DESCRIPTION
- Added `token` and `refresh` routes using Simple JWT for authentication
- Refactored `auth` views by removing repetitive `extend_schema` decorators
- Centralized all schema definitions into a single `schemas.py` file under `auths/`
- Added `run_tests.ps1` script in `shared/utils/` for simplified test execution